### PR TITLE
Updated link to Bandit due to openstack -> PyCQA ownership transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Codacy Bandit
 
-This is the docker engine we use at Codacy to have [Bandit](https://github.com/openstack/bandit) support.
+This is the docker engine we use at Codacy to have [Bandit](https://github.com/PyCQA/bandit) support.
 You can also create a docker to integrate the tool and language of your choice!
 Check the **Docs** section for more information.
 


### PR DESCRIPTION
Bandit is no longer maintained by openstack, it's maintained by PyCQA.
See https://github.com/openstack/bandit