### PR TITLE
fix B109 documentation

### DIFF
--- a/src/main/resources/docs/description/B109.md
+++ b/src/main/resources/docs/description/B109.md
@@ -1,56 +1,11 @@
-## Hardcoded temporary directory
+## Password based config option not marked secret
 
-### Problematic code:
-
-```python
-import os
-import tempfile
-
-# This will most certainly put you at risk
-tmp = os.path.join(tempfile.gettempdir(), filename)
-if not os.path.exists(tmp):
-    with open(tmp, "w") file:
-        file.write("defaults")
-```
-
-### Correct code:
-
-```python
-import os
-import tempfile
-
-# Use the TemporaryFile context manager for easy clean-up
-with tempfile.TemporaryFile() as tmp:
-    # Do stuff with tmp
-    tmp.write('stuff')
-
-# Clean up a NamedTemporaryFile on your own
-# delete=True means the file will be deleted on close
-tmp = tempfile.NamedTemporaryFile(delete=True)
-try:
-    # do stuff with temp
-    tmp.write('stuff')
-finally:
-    tmp.close()  # deletes the file
-
-# Handle opening the file yourself. This makes clean-up
-# more complex as you must watch out for exceptions
-fd, path = tempfile.mkstemp()
-try:
-    with os.fdopen(fd, 'w') as tmp:
-        # do stuff with temp file
-        tmp.write('stuff')
-finally:
-    os.remove(path)
-```
+This plugin has been removed.
 
 ### Rationale:
 
-Often we want to create temporary files to save data that we can’t hold in memory or to pass to external programs that must read from a file. 
-The obvious way to do this is to generate a unique file name in a common system temporary directory such as /tmp, but doing so correctly is harder than it seems. 
-We should never do this ourselves but use the correct existing library function. 
-We also must take care to cleanup our temporary files even in the face of errors.
+Passwords are sensitive and must be protected appropriately. In OpenStack Oslo there is an option to mark options "secret" which will ensure that they are not logged. This plugin detects usages of oslo configuration functions that appear to deal with strings ending in 'password' and flag usages where they have not been marked secret.
 
-[Reference](https://docs.openstack.org/bandit/latest/plugins/b109_password_config_option_not_marked_secret.html)
+If such a value is found a MEDIUM severity error is generated. If 'False' or 'None' are explicitly set, Bandit will return a MEDIUM confidence issue. If Bandit can't determine the value of secret it will return a LOW confidence issue.
 
-
+[Reference](https://bandit.readthedocs.io/en/latest/plugins/b109_password_config_option_not_marked_secret.html)


### PR DESCRIPTION
I am working on a script to auto update the documentation for codacy-bandit. Just updating this temporarily by hand because it was plain wrong and might mislead people.

Anyway, OpenStack-specific plugins were removed from bandit, so it wont detect this kind of patterns anymore: https://github.com/PyCQA/bandit/pull/311