### PR TITLE
security: Delay dependabot updates [TAROT-3707]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,14 @@
 version: 2
 updates:
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: daily
-    timezone: Europe/Lisbon
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: bandit
-    versions:
-    - 1.7.0
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+      timezone: Europe/Lisbon
+    open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: bandit
+        versions:
+          - 1.7.0
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
7 days should be enough when most malicious packages are patched within 24 hours.